### PR TITLE
feat: Add exclude directories/notes settings with regex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,31 @@ Creates ALL possible smart links in the entire line from the beginning.
 
 ## Configuration
 
-Current settings support:
+### Plugin Settings
 
-- **Case sensitivity**: Toggle between case-sensitive and case-insensitive matching  
+Access plugin settings through: Settings → Community Plugins → Smart Link → Settings
+
+#### Available Settings
+
+- **Case sensitivity**: Toggle between case-sensitive and case-insensitive matching
+- **Exclude Directories**: Prevent files in specific directories from appearing in smart link suggestions
+  - Enter directory paths relative to vault root (e.g., "Templates", "Archive/Old")
+  - Supports multiple entries with individual removal buttons
+- **Exclude Notes**: Exclude specific notes from smart link suggestions
+  - **NEW**: Supports regular expressions for powerful pattern matching
+  - Enter exact note names or regex patterns
+  - Examples:
+    - `Daily Notes Template` - Exclude specific note
+    - `^Draft.*` - Exclude all notes starting with "Draft"
+    - `.*Template$` - Exclude all notes ending with "Template"  
+    - `\d{4}-\d{2}-\d{2}` - Exclude date-formatted notes (YYYY-MM-DD)
+    - `(TODO|DONE|PENDING)` - Exclude notes containing status words
+    - `^_.*` - Exclude all notes starting with underscore
+  - Invalid regex patterns automatically fall back to exact string matching
+  - Supports multiple entries with individual removal buttons
+
+### Hotkey Configuration
+
 - **Custom hotkeys**: Modify hotkeys in Obsidian's Hotkeys settings
 
 ## Algorithm
@@ -246,11 +268,14 @@ If you find this plugin helpful, consider:
 ## Changelog
 
 ### Latest Version
+- ✨ **NEW**: Regular expression support for exclude notes patterns
 - ✨ **NEW**: "Create all smart links in line" command
 - ✨ **NEW**: Process entire lines with multiple links at once
 - ✨ **NEW**: Enhanced Korean particle handling for batch processing
+- ✨ **NEW**: Exclude directories and notes settings with UI management
 - 🐛 **FIXED**: Multiline boundary handling bug
-- 🧪 **IMPROVED**: Comprehensive test coverage with 30+ tests
+- 🐛 **FIXED**: Edge cases in date pattern matching (e.g., "2025-08-09 test")
+- 🧪 **IMPROVED**: Comprehensive test coverage with 80+ tests
 - 📚 **IMPROVED**: Better documentation and examples
 
 ### Previous Versions
@@ -261,8 +286,10 @@ If you find this plugin helpful, consider:
 
 ## Roadmap
 
-- [ ] Add settings page for customization
+- [x] ✅ Add settings page for customization (COMPLETED)
 - [x] ✅ Create all links in line (COMPLETED)
+- [x] ✅ Exclude directories and notes filtering (COMPLETED)
+- [x] ✅ Regular expression support for exclude patterns (COMPLETED)
 - [ ] Support for alias matching  
 - [ ] Multi-cursor support
 - [ ] Performance optimizations for very large vaults

--- a/main.ts
+++ b/main.ts
@@ -1,17 +1,30 @@
-import { Editor, MarkdownView, MarkdownFileInfo, Plugin, TFile } from 'obsidian'
+import {
+  Editor,
+  MarkdownView,
+  MarkdownFileInfo,
+  Plugin,
+  TFile,
+  App,
+  PluginSettingTab,
+  Setting,
+} from 'obsidian'
 import { SmartLinkCore, SmartLinkSettings, FileInfo } from './src/smartLink'
 
 const DEFAULT_SETTINGS: SmartLinkSettings = {
   caseSensitive: false,
+  excludeDirectories: [],
+  excludeNotes: [],
 }
 
 export default class SmartLinkPlugin extends Plugin {
   settings: SmartLinkSettings = DEFAULT_SETTINGS
-  private smartLinkCore!: SmartLinkCore
+  smartLinkCore!: SmartLinkCore
 
   async onload() {
     await this.loadSettings()
     this.smartLinkCore = new SmartLinkCore(this.settings)
+
+    this.addSettingTab(new SmartLinkSettingTab(this.app, this))
 
     this.addCommand({
       id: 'smart-link',
@@ -45,6 +58,7 @@ export default class SmartLinkPlugin extends Plugin {
     const allFiles = this.app.vault.getMarkdownFiles()
     const existingFiles: FileInfo[] = allFiles.map((file: TFile) => ({
       basename: file.basename,
+      path: file.path,
     }))
 
     // Get all link references (including non-existent files)
@@ -79,10 +93,18 @@ export default class SmartLinkPlugin extends Plugin {
       })
     })
 
-    // Convert to FileInfo array
-    return Array.from(allLinkNames).map((name) => ({
-      basename: name,
-    }))
+    // Convert to FileInfo array and apply filtering
+    const allFileInfos = Array.from(allLinkNames).map((name) => {
+      // Try to find the actual file to get its path
+      const actualFile = allFiles.find((f) => f.basename === name)
+      return {
+        basename: name,
+        path: actualFile?.path,
+      }
+    })
+
+    // Filter files based on exclude settings
+    return this.smartLinkCore.filterFiles(allFileInfos)
   }
 
   private createSmartLink(editor: Editor) {
@@ -116,5 +138,132 @@ export default class SmartLinkPlugin extends Plugin {
       { line: cursor.line, ch: 0 },
       { line: cursor.line, ch: line.length }
     )
+  }
+}
+
+class SmartLinkSettingTab extends PluginSettingTab {
+  plugin: SmartLinkPlugin
+
+  constructor(app: App, plugin: SmartLinkPlugin) {
+    super(app, plugin)
+    this.plugin = plugin
+  }
+
+  display(): void {
+    const { containerEl } = this
+
+    containerEl.empty()
+
+    containerEl.createEl('h2', { text: 'Smart Link Settings' })
+
+    // Case sensitivity setting
+    new Setting(containerEl)
+      .setName('Case sensitive matching')
+      .setDesc('Enable case-sensitive matching for smart links')
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.caseSensitive).onChange(async (value) => {
+          this.plugin.settings.caseSensitive = value
+          await this.plugin.saveSettings()
+          this.plugin.smartLinkCore = new SmartLinkCore(this.plugin.settings)
+        })
+      )
+
+    // Exclude directories section
+    containerEl.createEl('h3', { text: 'Exclude Directories' })
+    containerEl.createEl('p', {
+      text: 'Files in these directories will not be included in smart link suggestions. Enter directory paths relative to vault root.',
+      cls: 'setting-item-description',
+    })
+
+    // Add directory input
+    const addDirSetting = new Setting(containerEl)
+      .setName('Add directory to exclude')
+      .setDesc('Enter a directory path (e.g., "Templates" or "Archive/Old")')
+
+    let dirInput: HTMLInputElement
+    addDirSetting
+      .addText((text) => {
+        dirInput = text.inputEl
+        text.setPlaceholder('Enter directory path')
+      })
+      .addButton((button) =>
+        button
+          .setButtonText('Add')
+          .setCta()
+          .onClick(async () => {
+            const dirPath = dirInput.value.trim()
+            if (dirPath && !this.plugin.settings.excludeDirectories.includes(dirPath)) {
+              this.plugin.settings.excludeDirectories.push(dirPath)
+              await this.plugin.saveSettings()
+              this.plugin.smartLinkCore = new SmartLinkCore(this.plugin.settings)
+              dirInput.value = ''
+              this.display() // Refresh to show the new item
+            }
+          })
+      )
+
+    // List current excluded directories
+    this.plugin.settings.excludeDirectories.forEach((dir, index) => {
+      new Setting(containerEl).setName(dir).addButton((button) =>
+        button
+          .setButtonText('Remove')
+          .setWarning()
+          .onClick(async () => {
+            this.plugin.settings.excludeDirectories.splice(index, 1)
+            await this.plugin.saveSettings()
+            this.plugin.smartLinkCore = new SmartLinkCore(this.plugin.settings)
+            this.display() // Refresh to remove the item
+          })
+      )
+    })
+
+    // Exclude notes section
+    containerEl.createEl('h3', { text: 'Exclude Notes' })
+    containerEl.createEl('p', {
+      text: 'These specific notes will not be included in smart link suggestions. Enter note names without the .md extension. Supports regular expressions (e.g., "^Draft.*" to exclude all notes starting with "Draft").',
+      cls: 'setting-item-description',
+    })
+
+    // Add note input
+    const addNoteSetting = new Setting(containerEl)
+      .setName('Add note to exclude')
+      .setDesc('Enter a note name or regex pattern (e.g., "Daily Notes Template" or "^Draft.*")')
+
+    let noteInput: HTMLInputElement
+    addNoteSetting
+      .addText((text) => {
+        noteInput = text.inputEl
+        text.setPlaceholder('Enter note name')
+      })
+      .addButton((button) =>
+        button
+          .setButtonText('Add')
+          .setCta()
+          .onClick(async () => {
+            const noteName = noteInput.value.trim()
+            if (noteName && !this.plugin.settings.excludeNotes.includes(noteName)) {
+              this.plugin.settings.excludeNotes.push(noteName)
+              await this.plugin.saveSettings()
+              this.plugin.smartLinkCore = new SmartLinkCore(this.plugin.settings)
+              noteInput.value = ''
+              this.display() // Refresh to show the new item
+            }
+          })
+      )
+
+    // List current excluded notes
+    this.plugin.settings.excludeNotes.forEach((note, index) => {
+      new Setting(containerEl).setName(note).addButton((button) =>
+        button
+          .setButtonText('Remove')
+          .setWarning()
+          .onClick(async () => {
+            this.plugin.settings.excludeNotes.splice(index, 1)
+            await this.plugin.saveSettings()
+            this.plugin.smartLinkCore = new SmartLinkCore(this.plugin.settings)
+            this.display() // Refresh to remove the item
+          })
+      )
+    })
   }
 }

--- a/test/filtering.integration.test.ts
+++ b/test/filtering.integration.test.ts
@@ -1,0 +1,306 @@
+import { Editor, TFile } from './mocks/obsidian'
+import SmartLinkPlugin from '../main'
+import { SmartLinkCore } from '../src/smartLink'
+import type { Editor as ObsidianEditor, App, PluginManifest } from 'obsidian'
+
+// Mock Obsidian App and Vault
+interface MockApp {
+  vault: {
+    getMarkdownFiles: jest.Mock
+  }
+  metadataCache: {
+    unresolvedLinks: Record<string, unknown>
+    resolvedLinks: Record<string, unknown>
+  }
+  loadData: jest.Mock
+  saveData: jest.Mock
+  addCommand: jest.Mock
+  addSettingTab: jest.Mock
+}
+
+const mockApp: MockApp = {
+  vault: {
+    getMarkdownFiles: jest.fn(),
+  },
+  metadataCache: {
+    unresolvedLinks: {},
+    resolvedLinks: {},
+  },
+  loadData: jest.fn(),
+  saveData: jest.fn(),
+  addCommand: jest.fn(),
+  addSettingTab: jest.fn(),
+}
+
+const mockManifest: PluginManifest = {
+  id: 'test-plugin',
+  name: 'Test Plugin',
+  author: 'Test Author',
+  version: '1.0.0',
+  minAppVersion: '0.15.0',
+  description: 'Test plugin',
+}
+
+describe('Filtering Integration Tests', () => {
+  let plugin: SmartLinkPlugin
+  let mockFiles: TFile[]
+
+  beforeEach(() => {
+    plugin = new SmartLinkPlugin(mockApp as unknown as App, mockManifest)
+    plugin.app = mockApp as unknown as App
+    plugin.settings = {
+      caseSensitive: false,
+      excludeDirectories: [],
+      excludeNotes: [],
+    }
+
+    // Reset mocks
+    jest.clearAllMocks()
+
+    // Default mock files
+    mockFiles = [
+      new TFile('My Note'),
+      new TFile('Template'),
+      new TFile('Daily Template'),
+      new TFile('Project Note'),
+      new TFile('Archive Note'),
+    ]
+
+    // Override paths for some files
+    mockFiles[1].path = 'Templates/Template.md' // Template
+    mockFiles[2].path = 'Templates/Daily Template.md' // Daily Template
+    mockFiles[3].path = 'Projects/Project Note.md' // Project Note
+    mockFiles[4].path = 'Archive/Old/Archive Note.md' // Archive Note
+
+    mockApp.vault.getMarkdownFiles.mockReturnValue(mockFiles)
+  })
+
+  describe('excludeNotes integration', () => {
+    test('Should exclude specific notes from smart link creation', () => {
+      // Setup: exclude specific notes
+      plugin.settings.excludeNotes = ['Template', 'Daily Template']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('I need a template for my project', { line: 0, ch: 10 })
+
+      // Call createSmartLink - should not find "Template" because it's excluded
+      plugin['createSmartLink'](editor as unknown as ObsidianEditor)
+
+      // Should not create a link since "Template" is excluded
+      expect(editor.getContent()).toBe('I need a template for my project')
+    })
+
+    test('Should allow non-excluded notes to be linked', () => {
+      // Setup: exclude only specific notes
+      plugin.settings.excludeNotes = ['Template']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('I need project note details', { line: 0, ch: 10 })
+
+      // Call createSmartLink - should find "Project Note" since it's not excluded
+      plugin['createSmartLink'](editor as unknown as ObsidianEditor)
+
+      // Should create a link for "Project Note"
+      expect(editor.getContent()).toContain('[[Project Note]]')
+    })
+
+    test('Should work with createAllSmartLinks command', () => {
+      // Setup: exclude specific notes
+      plugin.settings.excludeNotes = ['Template']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('My Note and Project Note are important', { line: 0, ch: 0 })
+
+      // Call createAllSmartLinks
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
+
+      // Should create links for non-excluded notes
+      const result = editor.getContent()
+      expect(result).toContain('[[My Note]]')
+      expect(result).toContain('[[Project Note]]')
+      expect(result).not.toContain('[[Template]]')
+    })
+  })
+
+  describe('excludeDirectories integration', () => {
+    test('Should exclude files from specific directories', () => {
+      // Setup: exclude Templates directory
+      plugin.settings.excludeDirectories = ['Templates']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('I need a template for my work', { line: 0, ch: 10 })
+
+      // Call createSmartLink - should not find templates in Templates directory
+      plugin['createSmartLink'](editor as unknown as ObsidianEditor)
+
+      // Should not create a link since files in Templates are excluded
+      expect(editor.getContent()).toBe('I need a template for my work')
+    })
+
+    test('Should exclude nested directories', () => {
+      // Setup: exclude nested Archive/Old directory
+      plugin.settings.excludeDirectories = ['Archive/Old']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('Check the archive note', { line: 0, ch: 10 })
+
+      // Call createSmartLink
+      plugin['createSmartLink'](editor as unknown as ObsidianEditor)
+
+      // Should not create link since Archive Note is in Archive/Old
+      expect(editor.getContent()).toBe('Check the archive note')
+    })
+
+    test('Should handle directory exclusion with trailing slash', () => {
+      // Setup: exclude Templates directory with trailing slash
+      plugin.settings.excludeDirectories = ['Templates/']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('I need a template', { line: 0, ch: 10 })
+
+      plugin['createSmartLink'](editor as unknown as ObsidianEditor)
+
+      // Should not create link since Templates files are excluded
+      expect(editor.getContent()).toBe('I need a template')
+    })
+
+    test('Should allow files from non-excluded directories', () => {
+      // Setup: exclude only Templates
+      plugin.settings.excludeDirectories = ['Templates']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('Check my note, project note and archive note', { line: 0, ch: 0 })
+
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
+
+      const result = editor.getContent()
+      expect(result).toContain('[[My Note]]')
+      expect(result).toContain('[[Project Note]]')
+      // Should not exclude Archive Note since Archive/Old is not in excludeDirectories
+      expect(result).toContain('[[Archive Note]]')
+    })
+  })
+
+  describe('Combined exclusions integration', () => {
+    test('Should apply both directory and note exclusions', () => {
+      // Setup: exclude Templates directory AND specific note
+      plugin.settings.excludeDirectories = ['Templates']
+      plugin.settings.excludeNotes = ['Archive Note']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor(
+        'My Note, Template, Daily Template, Project Note, and Archive Note',
+        { line: 0, ch: 0 }
+      )
+
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
+
+      const result = editor.getContent()
+      expect(result).toContain('[[My Note]]') // Should be linked
+      expect(result).toContain('[[Project Note]]') // Should be linked
+      expect(result).not.toContain('[[Template]]') // Excluded by directory
+      expect(result).not.toContain('[[Daily Template]]') // Excluded by directory
+      expect(result).not.toContain('[[Archive Note]]') // Excluded by note name
+    })
+
+    test('Should handle file excluded by both methods', () => {
+      // Setup: Template is excluded both by directory AND by note name
+      plugin.settings.excludeDirectories = ['Templates']
+      plugin.settings.excludeNotes = ['Template']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('I need a template', { line: 0, ch: 10 })
+
+      plugin['createSmartLink'](editor as unknown as ObsidianEditor)
+
+      // Should not create link (excluded by both methods)
+      expect(editor.getContent()).toBe('I need a template')
+    })
+  })
+
+  describe('Edge cases', () => {
+    test('Should handle empty exclude lists', () => {
+      // Setup: empty exclusion lists (default)
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('My Note and Template work', { line: 0, ch: 0 })
+
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
+
+      const result = editor.getContent()
+      expect(result).toContain('[[My Note]]')
+      expect(result).toContain('[[Template]]')
+    })
+
+    test('Should handle files with no path information', () => {
+      // Setup mock files without complete path info
+      const filesWithoutPaths = [{ basename: 'No Path Note' } as TFile, new TFile('Regular Note')]
+      mockApp.vault.getMarkdownFiles.mockReturnValue(filesWithoutPaths)
+
+      plugin.settings.excludeDirectories = ['Templates']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      const editor = new Editor('No Path Note and Regular Note', { line: 0, ch: 0 })
+
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
+
+      const result = editor.getContent()
+      expect(result).toContain('[[No Path Note]]') // Should work even without path
+      expect(result).toContain('[[Regular Note]]')
+    })
+
+    test('Should handle case sensitivity with exclusions', () => {
+      plugin.settings.caseSensitive = true
+      plugin.settings.excludeNotes = ['template'] // lowercase
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      // Mock files with mixed case
+      const mixedCaseFiles = [
+        new TFile('Template'), // uppercase T
+        new TFile('template'), // lowercase t
+      ]
+      mockApp.vault.getMarkdownFiles.mockReturnValue(mixedCaseFiles)
+
+      const editor = new Editor('Template and template', { line: 0, ch: 0 })
+
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
+
+      const result = editor.getContent()
+      expect(result).toContain('[[Template]]') // Should be linked (not excluded)
+      expect(result).not.toContain('[[template]]') // Should be excluded
+    })
+  })
+
+  describe('Real-world scenarios', () => {
+    test('Should handle complex exclusion scenarios', () => {
+      // Simulate a typical user setup
+      plugin.settings.excludeDirectories = ['Templates', 'Archive/Old', 'Drafts']
+      plugin.settings.excludeNotes = ['TODO Template', 'Daily Note Template']
+      plugin.smartLinkCore = new SmartLinkCore(plugin.settings)
+
+      // Add more diverse mock files
+      const complexMockFiles = [
+        { basename: 'Important Note', path: 'Important Note.md' },
+        { basename: 'TODO Template', path: 'Templates/TODO Template.md' },
+        { basename: 'Meeting Notes', path: 'Work/Meeting Notes.md' },
+        { basename: 'Old Project', path: 'Archive/Old/Old Project.md' },
+        { basename: 'Draft Article', path: 'Drafts/Draft Article.md' },
+      ] as TFile[]
+      mockApp.vault.getMarkdownFiles.mockReturnValue(complexMockFiles)
+
+      const editor = new Editor(
+        'Important Note, TODO Template, Meeting Notes, Old Project, Draft Article',
+        { line: 0, ch: 0 }
+      )
+
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
+
+      const result = editor.getContent()
+      expect(result).toContain('[[Important Note]]') // Should be linked
+      expect(result).toContain('[[Meeting Notes]]') // Should be linked
+      expect(result).not.toContain('[[TODO Template]]') // Excluded by both directory and note name
+      expect(result).not.toContain('[[Old Project]]') // Excluded by directory
+      expect(result).not.toContain('[[Draft Article]]') // Excluded by directory
+    })
+  })
+})

--- a/test/mocks/obsidian.ts
+++ b/test/mocks/obsidian.ts
@@ -60,6 +60,63 @@ export class Plugin {
   async saveData(_data: unknown): Promise<void> {}
 
   addCommand(_command: unknown): void {}
+
+  addSettingTab(_settingTab: unknown): void {}
+}
+
+export class App {}
+
+export class PluginSettingTab {
+  app: App
+  plugin: Plugin
+
+  constructor(app: App, plugin: Plugin) {
+    this.app = app
+    this.plugin = plugin
+  }
+
+  display(): void {}
+}
+
+export class Setting {
+  constructor(_containerEl: unknown) {}
+
+  setName(_name: string): this {
+    return this
+  }
+
+  setDesc(_desc: string): this {
+    return this
+  }
+
+  addToggle(_callback: (toggle: MockToggle) => void): this {
+    return this
+  }
+
+  addText(_callback: (text: MockText) => void): this {
+    return this
+  }
+
+  addButton(_callback: (button: MockButton) => void): this {
+    return this
+  }
+}
+
+interface MockToggle {
+  setValue(value: boolean): MockToggle
+  onChange(callback: (value: boolean) => void): MockToggle
+}
+
+interface MockText {
+  inputEl: HTMLInputElement
+  setPlaceholder(placeholder: string): MockText
+}
+
+interface MockButton {
+  setButtonText(text: string): MockButton
+  setCta(): MockButton
+  setWarning(): MockButton
+  onClick(callback: () => void): MockButton
 }
 
 export interface MarkdownView {}

--- a/test/plugin.integration.test.ts
+++ b/test/plugin.integration.test.ts
@@ -1,6 +1,7 @@
 import SmartLinkPlugin from '../main'
 import { Editor, TFile } from './mocks/obsidian'
 import { SmartLinkCore } from '../src/smartLink'
+import type { Editor as ObsidianEditor, App, PluginManifest } from 'obsidian'
 
 // <CHORUS_TAG>test</CHORUS_TAG>
 describe('SmartLinkPlugin Integration Tests', () => {
@@ -22,6 +23,15 @@ describe('SmartLinkPlugin Integration Tests', () => {
     },
   }
 
+  const mockManifest: PluginManifest = {
+    id: 'test-plugin',
+    name: 'Test Plugin',
+    author: 'Test Author',
+    version: '1.0.0',
+    minAppVersion: '0.15.0',
+    description: 'Test plugin',
+  }
+
   let plugin: SmartLinkPlugin
   let editor: Editor
 
@@ -37,9 +47,9 @@ describe('SmartLinkPlugin Integration Tests', () => {
       new TFile('Visual Studio Code'),
     ])
 
-    plugin = new SmartLinkPlugin(mockApp as unknown, {} as unknown)
-    plugin.settings = { caseSensitive: false }
-    plugin.app = mockApp as unknown
+    plugin = new SmartLinkPlugin(mockApp as unknown as App, mockManifest)
+    plugin.settings = { caseSensitive: false, excludeDirectories: [], excludeNotes: [] }
+    plugin.app = mockApp as unknown as App
     plugin['smartLinkCore'] = new SmartLinkCore(plugin.settings)
   })
 
@@ -48,7 +58,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'I love React and JavaScript programming'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe('I love [[React]] and [[JavaScript]] programming')
     })
@@ -57,7 +67,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = '인공지능과 머신러닝을 공부한다'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe('[[인공지능]]과 [[머신러닝]]을 공부한다')
     })
@@ -66,7 +76,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'Claude Code는 인공지능이다'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe('[[Claude Code]]는 [[인공지능]]이다')
     })
@@ -80,7 +90,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'I use Visual Studio Code for development'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe('I use [[Visual Studio Code]] for development')
     })
@@ -89,7 +99,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'I love [[React]] and JavaScript programming'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe('I love [[React]] and [[JavaScript]] programming')
     })
@@ -100,7 +110,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
 
       positions.forEach((position) => {
         editor = new Editor(content, { line: 0, ch: position })
-        plugin['createAllSmartLinks'](editor)
+        plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
         expect(editor.getLineContent(0)).toBe('I love [[React]] and [[JavaScript]] programming')
       })
     })
@@ -112,7 +122,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
 
       // Test createAllSmartLinks
       editor = new Editor(content, { line: 0, ch: 10 })
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
       expect(editor.getLineContent(0)).toBe('I love [[React]] and [[JavaScript]] programming')
     })
   })
@@ -122,7 +132,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = ''
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe('')
     })
@@ -131,7 +141,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'I love programming with various tools'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe('I love programming with various tools')
     })
@@ -140,7 +150,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'I love [[React and JavaScript programming'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toContain('[[JavaScript]]')
     })
@@ -148,7 +158,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
 
   describe('Settings integration', () => {
     test('Should respect case sensitivity setting', () => {
-      plugin.settings = { caseSensitive: true }
+      plugin.settings = { caseSensitive: true, excludeDirectories: [], excludeNotes: [] }
       plugin['smartLinkCore'] = new SmartLinkCore(plugin.settings)
 
       mockApp.vault.getMarkdownFiles = jest.fn(() => [new TFile('JavaScript')])
@@ -156,13 +166,13 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'I love javascript programming'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe('I love javascript programming')
     })
 
     test('Should work with case insensitive setting (default)', () => {
-      plugin.settings = { caseSensitive: false }
+      plugin.settings = { caseSensitive: false, excludeDirectories: [], excludeNotes: [] }
       plugin['smartLinkCore'] = new SmartLinkCore(plugin.settings)
 
       mockApp.vault.getMarkdownFiles = jest.fn(() => [new TFile('JavaScript')])
@@ -170,7 +180,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'I love javascript programming'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe('I love [[JavaScript]] programming')
     })
@@ -187,7 +197,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'Python with Django and FastAPI is powerful'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe(
         '[[Python]] with [[Django]] and [[FastAPI]] is powerful'
@@ -205,7 +215,7 @@ describe('SmartLinkPlugin Integration Tests', () => {
       const content = 'UnresolvedNote and ResolvedNote are interesting'
       editor = new Editor(content, { line: 0, ch: 0 })
 
-      plugin['createAllSmartLinks'](editor)
+      plugin['createAllSmartLinks'](editor as unknown as ObsidianEditor)
 
       expect(editor.getLineContent(0)).toBe(
         '[[UnresolvedNote]] and [[ResolvedNote]] are interesting'

--- a/test/processAllSmartLinks.feature.test.ts
+++ b/test/processAllSmartLinks.feature.test.ts
@@ -6,7 +6,11 @@ describe('ProcessAllSmartLinks Feature Tests', () => {
   let files: FileInfo[]
 
   beforeEach(() => {
-    smartLink = new SmartLinkCore({ caseSensitive: false })
+    smartLink = new SmartLinkCore({
+      caseSensitive: false,
+      excludeDirectories: [],
+      excludeNotes: [],
+    })
     files = []
   })
 


### PR DESCRIPTION
## Summary
- Add comprehensive settings UI with exclude directories and exclude notes functionality
- **NEW**: Regular expression support for exclude notes patterns with powerful pattern matching
- Add filterFiles() method to SmartLinkCore for exclusion logic  
- Create comprehensive test suites for filtering functionality (80+ total tests)
- Fix edge cases in date pattern matching (e.g., "2025-08-09 test" scenarios)
- Update README.md with detailed configuration documentation and examples

## Key Features
- **Exclude Directories**: Prevent files in specific directories from smart link suggestions
- **Exclude Notes with Regex**: Support both exact matches and regex patterns like:
  - `^Draft.*` - exclude all notes starting with "Draft"
  - `.*Template$` - exclude all notes ending with "Template"  
  - `\d{4}-\d{2}-\d{2}` - exclude date-formatted notes
  - `(TODO|DONE|PENDING)` - exclude notes containing status words
- **Smart UI**: Add/remove entries with validation and auto-refresh
- **Fallback Handling**: Invalid regex patterns fall back to exact string matching

## Test Coverage
- 4 new comprehensive test suites covering regex patterns, edge cases, and integration scenarios
- All 80 tests passing including existing functionality
- Covers complex regex patterns, invalid regex fallback, and real-world usage scenarios

## Documentation
- Updated README.md with detailed configuration section
- Added regex examples and usage patterns
- Updated changelog and roadmap to reflect completed features

🤖 Generated with [Claude Code](https://claude.ai/code)