### PR TITLE
feat: Exclude backtick-wrapped content from smart link replacement

### DIFF
--- a/src/smartLink.ts
+++ b/src/smartLink.ts
@@ -309,6 +309,7 @@ export class SmartLinkCore {
     for (let pos = 0; pos < searchText.length; pos++) {
       if (this.isPositionProcessed(pos, processedRegions)) continue
       if (this.isInsideWikiLink(line, pos)) continue
+      if (this.isInsideBackticks(line, pos)) continue
 
       // Skip whitespace - we don't want to start matching from a space
       if (/\s/.test(line[pos])) continue
@@ -650,6 +651,19 @@ export class SmartLinkCore {
 
     const linkEnd = line.indexOf(']]', linkStart)
     return linkEnd !== -1 && linkEnd >= position
+  }
+
+  private isInsideBackticks(line: string, position: number): boolean {
+    // Count backticks before the current position
+    let backtickCount = 0
+    for (let i = 0; i < position; i++) {
+      if (line[i] === '`') {
+        backtickCount++
+      }
+    }
+
+    // If odd number of backticks before position, we're inside backticks
+    return backtickCount % 2 === 1
   }
 
   private isValidWordMatch(line: string, start: number, end: number): boolean {

--- a/test/processAllSmartLinks.feature.test.ts
+++ b/test/processAllSmartLinks.feature.test.ts
@@ -159,6 +159,51 @@ describe('ProcessAllSmartLinks Feature Tests', () => {
 
       expect(result).toContain('[[JavaScript]]')
     })
+
+    test('Should not link text within backticks', () => {
+      files = [{ basename: 'React' }, { basename: 'JavaScript' }]
+      const line = 'Use `React.createElement()` in JavaScript'
+
+      const result = smartLink.processAllSmartLinks(line, files)
+
+      expect(result).toBe('Use `React.createElement()` in [[JavaScript]]')
+    })
+
+    test('Should handle multiple backtick sections', () => {
+      files = [{ basename: 'function' }, { basename: 'variable' }]
+      const line = 'The `function` keyword and `variable` declaration in JavaScript'
+
+      const result = smartLink.processAllSmartLinks(line, files)
+
+      expect(result).toBe('The `function` keyword and `variable` declaration in JavaScript')
+    })
+
+    test('Should link text outside backticks but not inside', () => {
+      files = [{ basename: 'Python' }]
+      const line = 'Python is great. Use `python --version` to check Python version'
+
+      const result = smartLink.processAllSmartLinks(line, files)
+
+      expect(result).toBe('[[Python]] is great. Use `python --version` to check [[Python]] version')
+    })
+
+    test('Korean: Should not link text within backticks', () => {
+      files = [{ basename: '함수' }, { basename: '변수' }]
+      const line = '`함수`와 변수를 선언한다'
+
+      const result = smartLink.processAllSmartLinks(line, files)
+
+      expect(result).toBe('`함수`와 [[변수]]를 선언한다')
+    })
+
+    test('Should not link within existing wiki links', () => {
+      files = [{ basename: 'React' }]
+      const line = 'This [[React]] is already linked'
+
+      const result = smartLink.processAllSmartLinks(line, files)
+
+      expect(result).toBe('This [[React]] is already linked')
+    })
   })
 
   describe('Performance scenarios', () => {


### PR DESCRIPTION
## Summary
- Prevents text within backticks from being converted to smart links
- Preserves inline code formatting in Obsidian notes
- Ensures `code examples` remain unchanged when processing smart links

## Changes
- Added `isInsideBackticks()` method to detect positions within backticks
- Modified `processAllSmartLinks()` to skip backtick-wrapped content  
- Added comprehensive test coverage for backtick exclusion scenarios

## Test Plan
- [x] Added unit tests for single backtick sections
- [x] Added tests for multiple backtick sections in one line
- [x] Added tests for mixed backtick and non-backtick content
- [x] Added tests for Korean text with backticks
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)