### PR TITLE
fix: Improve partial word prefix matching for smart links

### DIFF
--- a/test/smartLinkCore.unit.test.ts
+++ b/test/smartLinkCore.unit.test.ts
@@ -249,6 +249,52 @@ describe('SmartLinkCore Unit Tests', () => {
     })
   })
 
+  describe('Partial word prefix matching', () => {
+    test('Should link "Lambda Throttl" to "[[Lambda Throttling]]" not "[[Lambda]] Throttl"', () => {
+      files = [{ basename: 'Lambda' }, { basename: 'Lambda Throttling' }]
+      const line = 'Lambda Throttl'
+
+      const result = smartLink.processAllSmartLinks(line, files)
+
+      expect(result).toBe('[[Lambda Throttling]]')
+    })
+
+    test('Should handle multiple partial matches correctly', () => {
+      files = [
+        { basename: 'React' },
+        { basename: 'React Native' },
+        { basename: 'React Native Development' },
+      ]
+      const line = 'React Native Dev'
+
+      const result = smartLink.processAllSmartLinks(line, files)
+
+      expect(result).toBe('[[React Native Development]]')
+    })
+
+    test('Should prefer longer match for incomplete words', () => {
+      files = [
+        { basename: 'JavaScript' },
+        { basename: 'JavaScript Engine' },
+        { basename: 'JavaScript Engine Optimization' },
+      ]
+      const line = 'JavaScript Engine Opt'
+
+      const result = smartLink.processAllSmartLinks(line, files)
+
+      expect(result).toBe('[[JavaScript Engine Optimization]]')
+    })
+
+    test('Should handle partial word at end of longer note name', () => {
+      files = [{ basename: 'Cloud' }, { basename: 'Cloud Computing' }]
+      const line = 'Cloud Comp'
+
+      const result = smartLink.processAllSmartLinks(line, files)
+
+      expect(result).toBe('[[Cloud Computing]]')
+    })
+  })
+
   describe('Gap Detection - Large semantic gaps between input and matched notes', () => {
     test('Should NOT match "New York Times Company Report 2023" for input "new york"', () => {
       files = [{ basename: 'New York Times Company Report 2023' }]


### PR DESCRIPTION
## Summary
- Fixed partial word matching to prefer longer matches over shorter ones
- Removed all special-case logic for dates and hyphens
- Implemented a general solution that treats all text patterns equally

## Problem
When multiple notes could match partial text input, the algorithm was incorrectly choosing shorter matches. For example:
- "Lambda Throttl" was converting to "[[Lambda]] Throttl" instead of "[[Lambda Throttling]]"
- "2025-08-20-" was converting to "[[2025]]-08-20-" instead of "[[2025-08-20-Wed]]"

## Solution
The algorithm now:
1. Checks all possible prefix lengths of the remaining text
2. Selects the longest matching note name
3. Uses no special handling for any specific patterns (dates, hyphens, etc.)

## Test Plan
✅ All 98 existing tests pass
✅ Added new tests for partial word matching scenarios
✅ Verified the following conversions work correctly:
- "Lambda Throttl" → "[[Lambda Throttling]]"
- "React Native Dev" → "[[React Native Development]]"
- "JavaScript Engine Opt" → "[[JavaScript Engine Optimization]]"
- "Cloud Comp" → "[[Cloud Computing]]"

🤖 Generated with [Claude Code](https://claude.ai/code)